### PR TITLE
upgrade to version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ Set of functions for dealing with data from the electron microscopes at Utrecht 
 ## Info
 - Created by: Maarten Bransen
 - Email: m.bransen@uu.nl
+- Version: 2.0.0
 
 ## Installation
+
 ### PIP
 This package can be installed directly from GitHub using pip:
 ```
@@ -26,11 +28,12 @@ To update to the most recent version, use `pip install` with the `--upgrade` fla
 pip install --upgrade git+https://github.com/MaartenBransen/scm_electron_microscopes
 ```
 
-### Installing pytesseract / tesseract-OCR
-To use automatic scale bar calibration for the Tecnai and Talos microscopes, the [tesseract optical character recognition](https://github.com/tesseract-ocr/tesseract) tool is used, which must be installed separately. Installation files can be found [here](https://tesseract-ocr.github.io/tessdoc/Home.html). This is interfaced through the `pytesseract` package which can be installed normally using e.g. conda. Since this is an optional dependency, `pytesseract` is not installed by default. It may be necessary to point it towards your tesseract installation by changing the `pytesseract.pytesseract.tesseract_cmd` variable to the correct path, something like `tesseract_cmd = r'C:\Program Files\Tesseract-OCR\tesseract.exe'`. If pytesseract or tesseract-OCR is not found the function switches to semi-automatic mode where the user is asked to give the size and unit written next to the scalebar. For the other microscopes, the pixelsize is correctly encoded in the normal image metadata and these dependencies are not neccesary.
-
 ## Usage
 ### Tecnai 12, Tecnai 20, Tecnai 20feg, Talos120, Talos200
+
+**Note that since version 2.0.0 Pytesseract is no longer required as dependency**
+
+
 For these microscopes use the [tecnai](https://maartenbransen.github.io/scm_electron_microscopes/#scm_electron_microscopes.tecnai) or [talos](https://maartenbransen.github.io/scm_electron_microscopes/#scm_electron_microscopes.talos) class (these are identical, the alias `talos` is just provided for convenience), and create a class instance using the filename of the TEM image. This automatically loads the image, which is available as numpy.array as the `image` attribute:
 ```
 from scm_electron_microscopes import tecnai
@@ -56,7 +59,7 @@ For the Helios SEM use the [helios](https://maartenbransen.github.io/scm_electro
 from scm_electron_microscopes import helios
 
 em_data = helios('myimage.tif')
-image = em_data.load_image()
+image = em_data.get_image()
 ```
 
 Pixel sizes written in the metadata and available as a shortcut through a function:
@@ -74,3 +77,13 @@ This microscope is no longer around, but for older data you can use the `xl30sfe
 
 ### Utility functions
 Some utility functions for e.g. plotting a histogram are included in the [util](https://maartenbransen.github.io/scm_electron_microscopes/#scm_electron_microscopes.util) class
+
+
+## Changelog
+
+### Version 2.0.0
+Note that this version has some backwards incompatible changes:
+- `load_image` functions have been renamed to `get_image`
+- `load_metadata` functions have been renamed to `get_metadata`
+- `tecnai.get_pixelsize` no longer uses text recognition to read the scale bar. This is faster and removes Pytesseract and the Tesseract OCR as dependencies, but yields slightly different (and more accurate) values. The old scaling method is available through `get_pixelsize_legacy`.
+- all `get_metadata` functions now return an xml.etree.Elementtree object by default, rather than a dictionary which was used for some classes.

--- a/scm_electron_microscopes/__init__.py
+++ b/scm_electron_microscopes/__init__.py
@@ -1,7 +1,7 @@
 __version__ = '1.0.1'
 
 from .tem import tecnai
-from .sem import helios,phenom,xl30sfeg
+from .sem import helios,phenom,xl30sfeg,ZeissSEM
 from .utility import util
 
 #make talos alias for identical tecnai/talos class
@@ -15,6 +15,7 @@ __all__ = [
     'helios',
     'phenom',
     'xl30sfeg',
+    'ZeissSEM',
     'util'
 ]
 

--- a/scm_electron_microscopes/__init__.py
+++ b/scm_electron_microscopes/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.1'
+__version__ = '2.0.0'
 
 from .tem import tecnai
 from .sem import helios,phenom,xl30sfeg,ZeissSEM

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -1,7 +1,9 @@
 import os
-import cv2
+#import cv2
 import numpy as np
 from .utility import util
+from PIL import Image
+from warnings import warn
 
 class helios:
     """
@@ -30,8 +32,10 @@ class helios:
                 raise FileNotFoundError('The file "'+filename+
                                         '" could not be found.')
         self.filename = filename
+        self.PIL_image = Image.open(self.filename)
+        self.shape = self.PIL_image.size[::-1]
     
-    def load_image(self):
+    def get_image(self):
         """
         load the image and split into image and databar
 
@@ -41,8 +45,7 @@ class helios:
             array of pixel values in the image (not including the data bar)
 
         """
-        im = cv2.imread(self.filename,0)
-        self.shape = np.shape(im)
+        im = np.array(self.PIL_image)
         self.image = im[:int(self.shape[1]/1.5)]
         if int(self.shape[1]/1.5) < self.shape[0]:
             self.databar = im[int(self.shape[1]/1.5):]
@@ -50,7 +53,7 @@ class helios:
             self.databar = None
         return self.image
     
-    def load_metadata(self):
+    def get_metadata(self):
         """
         Load the metadata footer from Helios SEM files and return xml tree
         object which can be indexed for extraction of useful parameters. Does
@@ -66,53 +69,27 @@ class helios:
             `xml_root.find('<element name>')`.
 
         """
-        import io
         import xml.etree.ElementTree as et
         
-        metadata = ''
-        read = False
-        
-        #for slice and view images the metadata is already in xml format
+        #two possible formats, 'standard' and images from slice and view series
+        #try first to get xml from slice and view
         try:
-            with io.open(self.filename, 'r', errors='ignore', encoding='utf8') as file:
-                #read file line by line to avoid loading too much into memory
-                for line in file:
-                    #start reading at the first line containing an xml tag
-                    if '<?xml' in line:
-                        read = True
-                    if read:
-                        metadata += line
-                        if '</Metadata>' in line:
-                            break #stop at line with end tag
-            
-            #trim strings down to only xml
-            metadata = metadata[metadata.find('<?xml'):]
-            metadata = metadata[:metadata.find('</Metadata>')+11]
-            
-            self.metadata = et.fromstring(metadata)
-            return self.metadata
-        
-        #otherwise construct the metadata from formatted metadata in file
-        except:
-            with io.open(self.filename, 'r', errors='ignore', encoding='utf8') as file:
-                for line in file:
-                    #start reading at first line with [User], break at next \x00
-                    if read:
-                        metadata += line
-                        if '\x00' in line:
-                            break
-                    if '[User]' in line:
-                        read = True
-                        metadata += line
-            
-            metadata = metadata[metadata.find('[User]'):]
-            metadata = metadata[:metadata.find('\x00')-2]
-            metadata = metadata.split('\n')
-            
-            #construct xml object
+            xml_root = et.fromstring(self.PIL_image.tag[34683][0])
+        except KeyError:
             xml_root = et.Element('MetaData')
+        
+        try:
+            #get value from tiff tag 34682 which contains the metadata in a 
+            #human readable format
+            metadata = self.PIL_image.tag[34682][0].split('\r\n')
+            
+            #check for empty metadata, raise keyerror for exception catching
+            if len(metadata) == 0:
+                raise KeyError
+            
+            #construct/add to xml object
             for line in metadata:
-                if line != '':
+                if line:#if not empty line
                     if line[0] == '[':
                         child = et.SubElement(xml_root,line[1:-1])
                     else:
@@ -120,8 +97,14 @@ class helios:
                         subchild = et.SubElement(child,line[0])
                         subchild.text = line[1]
             
+            #store and return xml root
             self.metadata = xml_root
             return xml_root
+        
+        #if the metadata key is not found in the image
+        except KeyError:
+            warn('no metadata found')
+            return None
     
     def print_metadata(self):
         """print formatted output of metadata"""
@@ -129,7 +112,7 @@ class helios:
         try:
             xml_root = self.metadata
         except AttributeError:
-            xml_root = self.load_metadata()
+            xml_root = self.get_metadata()
         
         util.print_metadata(xml_root)
         
@@ -140,8 +123,8 @@ class helios:
 
         Returns
         -------
-        pixelsize : float
-            the pixelsize in calibrated (physical) units
+        pixelsize : tuple of float
+            the pixelsize in calibrated (physical) units in (x,y)
         unit : string
             the physical unit of the pixel size
 
@@ -150,15 +133,19 @@ class helios:
         try:
             xml_root = self.metadata
         except AttributeError:
-            xml_root = self.load_metadata()
+            xml_root = self.get_metadata()
         
         #find the pixelsize (may be two different formats)
         try:
             pixelsize_x = float(xml_root.find('Scan').find('PixelWidth').text)
             pixelsize_y = float(xml_root.find('Scan').find('PixelHeight').text)
         except:
-            pixelsize_x = float(xml_root.find('BinaryResult').find('PixelSize').find('X').text)
-            pixelsize_y = float(xml_root.find('BinaryResult').find('PixelSize').find('Y').text)
+            pixelsize_x = float(
+                xml_root.find('BinaryResult').find('PixelSize').find('X').text
+            )
+            pixelsize_y = float(
+                xml_root.find('BinaryResult').find('PixelSize').find('Y').text
+            )
         
         #find the right unit and rescale for convenience
         if pixelsize_x >= 0.1:
@@ -174,17 +161,17 @@ class helios:
             pixelsize_x,pixelsize_y = 1e9*pixelsize_x,1e9*pixelsize_y
         
         pixelsize = (pixelsize_x,pixelsize_y)
-        print('Pixel size x: {:.6g}'.format(pixelsize[0]),unit)
-        print('Pixel size y: {:.6g}'.format(pixelsize[1]),unit)
         
-        self.pixelsize= pixelsize
+        #print pixel size
+        #print('Pixel size x: {:.6g}'.format(pixelsize[0]),unit)
+        #print('Pixel size y: {:.6g}'.format(pixelsize[1]),unit)
+        
+        self.pixelsize = pixelsize
         self.unit = unit
         
         return pixelsize,unit
     
-    def export_with_scalebar(self,filename=None,barsize=None,crop=None,scale=1,
-                             loc=2,resolution=None,box=True,invert=False, 
-                             convert=None):
+    def export_with_scalebar(self, filename=None, **kwargs):
         """
         saves an exported image of the SEM image with a scalebar in one of the 
         four corners, where barsize is the scalebar size in data units (e.g. 
@@ -195,13 +182,8 @@ class helios:
         ----------
         filename : string or `None`, optional
             Filename + extension to use for the export file. The default is the
-            filename sans extension of the original TEM file, with 
+            filename sans extension of the original SEM file, with 
             '_exported.png' appended.
-        barsize : float or `None`, optional
-            size (in data units matching the original scale bar, e.g. nm) of 
-            the scale bar to use. The default `None`, wich takes the desired 
-            length for the current scale and round this to the nearest option
-            from a list of "nice" values.
         crop : tuple or `None`, optional 
             range describing a area of the original image (before rescaling the
             resolution) to crop out for the export image. Can have two forms:
@@ -214,6 +196,19 @@ class helios:
             optional rescaling using `resolution`).
             
             The default is `None` which takes the entire image.
+        resolution : int, optional
+            the resolution along the x-axis (i.e. image width in pixels) to use
+            for the exported image. The default is `None`, which uses the size 
+            of the original image (after optional cropping using `crop`).
+        draw_bar : boolean, optional
+            whether to draw a scalebar on the image, such that this function 
+            may be used just to strip the original bar and crop. The default is
+            `True`.
+        barsize : float or `None`, optional
+            size (in data units matching the original scale bar, e.g. nm) of 
+            the scale bar to use. The default `None`, wich takes the desired 
+            length for the current scale and round this to the nearest option
+            from a list of "nice" values.
         scale : float, optional
             factor to change the size of the scalebar+text with respect to the
             width of the image. Scale is chosen such, that at `scale=1` the
@@ -224,21 +219,43 @@ class helios:
             Location of the scalebar on the image, where `0`, `1`, `2` and `3` 
             refer to the top left, top right, bottom left and bottom right 
             respectively. The default is `2`, which is the bottom left corner.
-        resolution : int, optional
-            the resolution along the x-axis (i.e. image width in pixels) to use
-            for the exported image. The default is `None`, which uses the size 
-            of the original image (after optional cropping using `crop`).
-        box : bool, optional
-            Whether to put a semitransparent box around the scalebar and text
-            to enhance contrast. The default is `True`.
-        invert : bool, optional
-            If `True`, a white scalebar and text on a black box are used. The 
-            default is `False` which gives black text on a white background.
-        convert : str, one of [`pm`,`nm`,`um`,`µm`,`mm`,`m`], optional
+        convert : one of ['pm', 'nm', 'um', 'µm', 'mm', 'm', None], optional
             Unit that will be used for the scale bar, the value will be 
             automatically converted if this unit differs from the pixel size
             unit. The default is `None`, which uses the unit of the scalebar on
             the original image.
+        font : str, optional
+            filename of an installed TrueType font ('.ttf' file) to use for the
+            text on the scalebar. The default is `'arialbd.ttf'`.
+        fontsize : int, optional
+            base font size to use for the scale bar text. The default is 16. 
+            Note that this size will be re-scaled according to `resolution` and
+            `scale`.
+        fontbaseline : int, optional
+            vertical offset for the baseline of the scale bar text in printer
+             points. The default is 0.
+        fontpad : int, optional
+            minimum size in printer points of the space/padding between the 
+            text and the bar and surrounding box. The default is 2.
+        barthickness : int, optional
+            thickness in printer points of the scale bar itself. The default is
+            16.
+        barpad : int, optional
+            size in printer points of the padding between the scale bar and the
+            surrounding box. The default is 10.
+        box : bool, optional
+            Whether to put a semitransparent box around the scalebar and text
+            to enhance contrast. The default is `True`.
+        boxalpha : float, optional
+            value between 0 and 1 for the opacity (inverse of transparency) of
+            the box behind the scalebar and text when `box=True`. The default 
+            is `0.6`.
+        invert : bool, optional
+            If `True`, a white scalebar and text on a black box are used. The 
+            default is `False` which gives black text on a white background.
+        boxpad : int, optional
+            size of the space/padding around the box (with respect to the sides
+            of the image) in printer points. The default is 10.
         """
         #check if pixelsize already calculated, otherwise call get_pixelsize
         try:
@@ -259,13 +276,11 @@ class helios:
         try:
             exportim = self.image.copy()
         except AttributeError:
-            exportim = self.load_image().copy()
+            exportim = self.get_image().copy()
         
         #call main export_with_scalebar function with correct pixelsize etc
         from .utility import _export_with_scalebar
-        _export_with_scalebar(exportim, pixelsize[0], unit, filename, barsize, 
-                              crop, scale, loc, resolution, box, invert, 
-                              convert)
+        _export_with_scalebar(exportim, pixelsize[0], unit, filename, **kwargs)
 
 
 #==============================================================================
@@ -287,21 +302,24 @@ class phenom:
     def __init__(self,filename):
         #raise error if wrong format or file does not exist
         if type(filename) != str:
-            raise TypeError('The argument to the helios class must be a string containing the filename.')
+            raise TypeError('The argument to the helios class must be a string'
+                            ' containing the filename.')
         if not os.path.exists(filename):
-            raise FileNotFoundError('The file "'+filename+'" could not be found.')
+            raise FileNotFoundError('The file "'+filename+
+                                    '" could not be found.')
             
         self.filename = filename
+        self.PIL_image = Image.open(filename)
+        self.shape = self.PIL_image.size[::-1]
     
-    def load_image(self):
+    def get_image(self):
         """load the image and split into image and databar"""
-        im = cv2.imread(self.filename,0)
-        self.shape = np.shape(im)
+        im = np.array(self.PIL_image)
         self.image = im[:int(self.shape[1])]
         self.databar = im[int(self.shape[1]):]
         return self.image
     
-    def load_metadata(self):
+    def get_metadata(self):
         """Load the metadata footer from Helios SEM files and return xml tree
         object which can be indexed for extraction of useful parameters. Does
         not require loading whole file into memory. Attempts first to find xml
@@ -348,7 +366,7 @@ class phenom:
         try:
             xml_root = self.metadata
         except AttributeError:
-            xml_root = self.load_metadata()
+            xml_root = self.get_metadata()
         
         util.print_metadata(xml_root)
     
@@ -368,14 +386,15 @@ class phenom:
         try:
             xml_root = self.metadata
         except AttributeError:
-            xml_root = self.load_metadata()
+            xml_root = self.get_metadata()
         
         #find the pixelsize (may be two different formats)
         pixelsize_x = float(xml_root.find('pixelWidth').text)
         pixelsize_y = float(xml_root.find('pixelHeight').text)
         
         #get the unit
-        if xml_root.find('pixelWidth').attrib['unit'] != xml_root.find('pixelHeight').attrib['unit']:
+        if xml_root.find('pixelWidth').attrib['unit'] != \
+            xml_root.find('pixelHeight').attrib['unit']:
             print('[WARNING] Unit for x and y not the same, using x unit')
         unit = xml_root.find('pixelWidth').attrib['unit']
         if unit == 'um':
@@ -391,9 +410,7 @@ class phenom:
         
         return pixelsize,unit
 
-    def export_with_scalebar(self,filename=None,barsize=None,crop=None,scale=1,
-                             loc=2,resolution=None,box=True,invert=False,
-                             convert=None):
+    def export_with_scalebar(self, filename=None, **kwargs):
         """
         saves an exported image of the SEM image with a scalebar in one of the 
         four corners, where barsize is the scalebar size in data units (e.g. 
@@ -404,13 +421,8 @@ class phenom:
         ----------
         filename : string or `None`, optional
             Filename + extension to use for the export file. The default is the
-            filename sans extension of the original TEM file, with 
+            filename sans extension of the original SEM file, with 
             '_exported.png' appended.
-        barsize : float or `None`, optional
-            size (in data units matching the original scale bar, e.g. nm) of 
-            the scale bar to use. The default `None`, wich takes the desired 
-            length for the current scale and round this to the nearest option
-            from a list of "nice" values.
         crop : tuple or `None`, optional 
             range describing a area of the original image (before rescaling the
             resolution) to crop out for the export image. Can have two forms:
@@ -423,6 +435,19 @@ class phenom:
             optional rescaling using `resolution`).
             
             The default is `None` which takes the entire image.
+        resolution : int, optional
+            the resolution along the x-axis (i.e. image width in pixels) to use
+            for the exported image. The default is `None`, which uses the size 
+            of the original image (after optional cropping using `crop`).
+        draw_bar : boolean, optional
+            whether to draw a scalebar on the image, such that this function 
+            may be used just to strip the original bar and crop. The default is
+            `True`.
+        barsize : float or `None`, optional
+            size (in data units matching the original scale bar, e.g. nm) of 
+            the scale bar to use. The default `None`, wich takes the desired 
+            length for the current scale and round this to the nearest option
+            from a list of "nice" values.
         scale : float, optional
             factor to change the size of the scalebar+text with respect to the
             width of the image. Scale is chosen such, that at `scale=1` the
@@ -433,21 +458,43 @@ class phenom:
             Location of the scalebar on the image, where `0`, `1`, `2` and `3` 
             refer to the top left, top right, bottom left and bottom right 
             respectively. The default is `2`, which is the bottom left corner.
-        resolution : int, optional
-            the resolution along the x-axis (i.e. image width in pixels) to use
-            for the exported image. The default is `None`, which uses the size 
-            of the original image (after optional cropping using `crop`).
-        box : bool, optional
-            Whether to put a semitransparent box around the scalebar and text
-            to enhance contrast. The default is `True`.
-        invert : bool, optional
-            If `True`, a white scalebar and text on a black box are used. The 
-            default is `False` which gives black text on a white background.
-        convert : str, one of [`pm`,`nm`,`um`,`µm`,`mm`,`m`], optional
+        convert : one of ['pm', 'nm', 'um', 'µm', 'mm', 'm', None], optional
             Unit that will be used for the scale bar, the value will be 
             automatically converted if this unit differs from the pixel size
             unit. The default is `None`, which uses the unit of the scalebar on
-            the original image..
+            the original image.
+        font : str, optional
+            filename of an installed TrueType font ('.ttf' file) to use for the
+            text on the scalebar. The default is `'arialbd.ttf'`.
+        fontsize : int, optional
+            base font size to use for the scale bar text. The default is 16. 
+            Note that this size will be re-scaled according to `resolution` and
+            `scale`.
+        fontbaseline : int, optional
+            vertical offset for the baseline of the scale bar text in printer
+             points. The default is 0.
+        fontpad : int, optional
+            minimum size in printer points of the space/padding between the 
+            text and the bar and surrounding box. The default is 2.
+        barthickness : int, optional
+            thickness in printer points of the scale bar itself. The default is
+            16.
+        barpad : int, optional
+            size in printer points of the padding between the scale bar and the
+            surrounding box. The default is 10.
+        box : bool, optional
+            Whether to put a semitransparent box around the scalebar and text
+            to enhance contrast. The default is `True`.
+        boxalpha : float, optional
+            value between 0 and 1 for the opacity (inverse of transparency) of
+            the box behind the scalebar and text when `box=True`. The default 
+            is `0.6`.
+        invert : bool, optional
+            If `True`, a white scalebar and text on a black box are used. The 
+            default is `False` which gives black text on a white background.
+        boxpad : int, optional
+            size of the space/padding around the box (with respect to the sides
+            of the image) in printer points. The default is 10.
         """
         #check if pixelsize already calculated, otherwise call get_pixelsize
         try:
@@ -468,13 +515,11 @@ class phenom:
         try:
             exportim = self.image.copy()
         except AttributeError:
-            exportim = self.load_image().copy()
+            exportim = self.get_image().copy()
         
         #call main export_with_scalebar function with correct pixelsize etc
         from .utility import _export_with_scalebar
-        _export_with_scalebar(exportim, pixelsize[0], unit, filename, barsize, 
-                              crop, scale, loc, resolution, box, invert, 
-                              convert)
+        _export_with_scalebar(exportim, pixelsize[0], unit, filename, **kwargs)
 
 
 class xl30sfeg:
@@ -493,17 +538,20 @@ class xl30sfeg:
     def __init__(self,filename):
         #raise error if wrong format or file does not exist
         if type(filename) != str:
-            raise TypeError('The argument to the xl30sfeg class must be a string containing the filename.')
+            raise TypeError('The argument to the xl30sfeg class must be a '
+                            'string containing the filename.')
         if not os.path.exists(filename):
-            raise FileNotFoundError('The file "'+filename+'" could not be found.')
+            raise FileNotFoundError('The file "'+filename+
+                                    '" could not be found.')
         
         self.filename = filename
+        self.PIL_image = Image.open(filename)
+        self.shape = self.PIL_image.size[::-1]
     
-    def load_image(self):
+    def get_image(self):
         """load the image and (if present) scalebar"""
-        im = cv2.imread(self.filename,0)
         
-        self.shape = np.shape(im)
+        im = np.array(self.PIL_image)
         self.image = im[:int(self.shape[1]/1.330)]
         
         #check if scalebar is present
@@ -513,10 +561,10 @@ class xl30sfeg:
         return self.image
     
     
-    def load_metadata(self):
-        """Load the metadata footer from XL30SFEG SEM files and return xml tree
-        object which can be indexed for extraction of useful parameters. Does 
-        not require loading whole file into memory. Searches for 'human' 
+    def get_metadata(self):
+        """Load the metadata footer from XL30SFEG SEM files and return xml 
+        tree object which can be indexed for extraction of useful parameters. 
+        Does not require loading whole file into memory. Searches for 'human' 
         formatted metadata.
 
         Returns
@@ -534,9 +582,11 @@ class xl30sfeg:
         read = False
          
         #construct the metadata from formatted metadata in file
-        with io.open(self.filename, 'r', errors='ignore', encoding='utf8') as file:
+        with io.open(self.filename, 'r', errors='ignore', encoding='utf8') \
+            as file:
             for line in file:
-                #start reading at first line with [DatabarData], break at last item
+                #start reading at first line with [DatabarData], break at last 
+                #item
                 if read:
                     metadata += line
                     if 'IonBright3' in line:
@@ -568,7 +618,7 @@ class xl30sfeg:
         try:
             xml_root = self.metadata
         except AttributeError:
-            xml_root = self.load_metadata()
+            xml_root = self.get_metadata()
         
         util.print_metadata(xml_root)
     
@@ -583,20 +633,20 @@ class xl30sfeg:
             physical unit corresponding to the pixelsize.
 
         """   
-        #try finding metadata, else call load_metadata
+        #try finding metadata, else call get_metadata
         try:
             self.metadata
         except AttributeError:
-            self.load_metadata()
+            self.get_metadata()
         
-        self.pixelsize = float(self.metadata.find('DatabarData').find('flMagn').text)
+        self.pixelsize = float(
+            self.metadata.find('DatabarData').find('flMagn').text
+        )
         self.unit = 'µm'
         
         return self.pixelsize,self.unit
 
-    def export_with_scalebar(self,filename=None,barsize=None,crop=None,scale=1,
-                             loc=2,resolution=None,box=True,invert=False, 
-                             convert=None):
+    def export_with_scalebar(self, filename=None, **kwargs):
         """
         saves an exported image of the SEM image with a scalebar in one of the 
         four corners, where barsize is the scalebar size in data units (e.g. 
@@ -607,13 +657,8 @@ class xl30sfeg:
         ----------
         filename : string or `None`, optional
             Filename + extension to use for the export file. The default is the
-            filename sans extension of the original TEM file, with 
+            filename sans extension of the original SEM file, with 
             '_exported.png' appended.
-        barsize : float or `None`, optional
-            size (in data units matching the original scale bar, e.g. nm) of 
-            the scale bar to use. The default `None`, wich takes the desired 
-            length for the current scale and round this to the nearest option
-            from a list of "nice" values.
         crop : tuple or `None`, optional 
             range describing a area of the original image (before rescaling the
             resolution) to crop out for the export image. Can have two forms:
@@ -626,6 +671,19 @@ class xl30sfeg:
             optional rescaling using `resolution`).
             
             The default is `None` which takes the entire image.
+        resolution : int, optional
+            the resolution along the x-axis (i.e. image width in pixels) to use
+            for the exported image. The default is `None`, which uses the size 
+            of the original image (after optional cropping using `crop`).
+        draw_bar : boolean, optional
+            whether to draw a scalebar on the image, such that this function 
+            may be used just to strip the original bar and crop. The default is
+            `True`.
+        barsize : float or `None`, optional
+            size (in data units matching the original scale bar, e.g. nm) of 
+            the scale bar to use. The default `None`, wich takes the desired 
+            length for the current scale and round this to the nearest option
+            from a list of "nice" values.
         scale : float, optional
             factor to change the size of the scalebar+text with respect to the
             width of the image. Scale is chosen such, that at `scale=1` the
@@ -636,21 +694,43 @@ class xl30sfeg:
             Location of the scalebar on the image, where `0`, `1`, `2` and `3` 
             refer to the top left, top right, bottom left and bottom right 
             respectively. The default is `2`, which is the bottom left corner.
-        resolution : int, optional
-            the resolution along the x-axis (i.e. image width in pixels) to use
-            for the exported image. The default is `None`, which uses the size 
-            of the original image (after optional cropping using `crop`).
-        box : bool, optional
-            Whether to put a semitransparent box around the scalebar and text
-            to enhance contrast. The default is `True`.
-        invert : bool, optional
-            If `True`, a white scalebar and text on a black box are used. The 
-            default is `False` which gives black text on a white background.
-        convert : str, one of [`pm`,`nm`,`um`,`µm`,`mm`,`m`], optional
+        convert : one of ['pm', 'nm', 'um', 'µm', 'mm', 'm', None], optional
             Unit that will be used for the scale bar, the value will be 
             automatically converted if this unit differs from the pixel size
             unit. The default is `None`, which uses the unit of the scalebar on
             the original image.
+        font : str, optional
+            filename of an installed TrueType font ('.ttf' file) to use for the
+            text on the scalebar. The default is `'arialbd.ttf'`.
+        fontsize : int, optional
+            base font size to use for the scale bar text. The default is 16. 
+            Note that this size will be re-scaled according to `resolution` and
+            `scale`.
+        fontbaseline : int, optional
+            vertical offset for the baseline of the scale bar text in printer
+             points. The default is 0.
+        fontpad : int, optional
+            minimum size in printer points of the space/padding between the 
+            text and the bar and surrounding box. The default is 2.
+        barthickness : int, optional
+            thickness in printer points of the scale bar itself. The default is
+            16.
+        barpad : int, optional
+            size in printer points of the padding between the scale bar and the
+            surrounding box. The default is 10.
+        box : bool, optional
+            Whether to put a semitransparent box around the scalebar and text
+            to enhance contrast. The default is `True`.
+        boxalpha : float, optional
+            value between 0 and 1 for the opacity (inverse of transparency) of
+            the box behind the scalebar and text when `box=True`. The default 
+            is `0.6`.
+        invert : bool, optional
+            If `True`, a white scalebar and text on a black box are used. The 
+            default is `False` which gives black text on a white background.
+        boxpad : int, optional
+            size of the space/padding around the box (with respect to the sides
+            of the image) in printer points. The default is 10.
         """
         #check if pixelsize already calculated, otherwise call get_pixelsize
         try:
@@ -664,21 +744,18 @@ class xl30sfeg:
         
         #check we're not overwriting the original file
         if filename==self.filename:
-            raise ValueError('overwriting original SEM file not recommended, '+
+            raise ValueError('overwriting original SEM file not recommended, '
                              'use a different filename for exporting.')
               
         #get and display image
         try:
             exportim = self.image.copy()
         except AttributeError:
-            exportim = self.load_image().copy()
+            exportim = self.get_image().copy()
         
         #call main export_with_scalebar function with correct pixelsize etc
         from .utility import _export_with_scalebar
-        _export_with_scalebar(exportim, pixelsize, unit, filename, barsize, 
-                              crop, scale, loc, resolution, box, invert, 
-                              convert)
-
+        _export_with_scalebar(exportim, pixelsize, unit, filename, **kwargs)
 
 
 class ZeissSEM:
@@ -688,7 +765,8 @@ class ZeissSEM:
     Parameters
     ----------
     filename : str
-        filename of the image to load
+        filename of the image to load. The file extension may be but is not 
+        required to be included.
         
     Returns
     -------
@@ -705,16 +783,17 @@ class ZeissSEM:
         else:
             raise FileNotFoundError('The file "'+filename+'" could not be '
                                     'found.')
+        self.PIL_image = Image.open(self.filename)
 
     
-    def load_image(self):
+    def get_image(self):
         """loads the image data
         
         Returns
         -------
         PIL.Image instance
         """
-        self.image = cv2.imread(self.filename,0)
+        self.image = np.array(self.PIL_image)
         self.shape = np.shape(self.image)
         return self.image
     
@@ -725,30 +804,42 @@ class ZeissSEM:
             return self.metadata
         
         #get correct tiftags from 
-        from PIL.Image import open as PIL_open
+        tifftags = self.PIL_image.tag
+        metadata = tifftags[34118][0].split('\r\n')
+        
+        #ignore numeric lines at the start
+        metadata = [line for line in metadata if not line[:1].isdigit()]
+        
+        #construct xml object
+        import xml.etree.ElementTree as et
+        xml_root = et.Element('MetaData')
+        
+        #make sure the first child exists
+        if '=' in metadata[0]:
+            child = et.SubElement(xml_root, 'None')
+        
+        #add (nested) items in loop over lines
+        for line in metadata:
+            if line:#skip empty
+                if not '=' in line:
+                    child = et.SubElement(xml_root, line.strip())
+                else:
+                    key,val = line.split(' = ')
+                    subchild = et.SubElement(child, key.strip())
+                    subchild.text = val.strip()
 
-        tifftags = PIL_open(self.filename).tag
-        md = tifftags[34118][0].replace('\r','').split('\n')
-        
-        metadata = dict()
-        for line in md:
-            #only accept if there's a '=' in the line
-            try:
-                key,val = line.split(' = ')
-                i = 0
-                thekey = key
-                while thekey in metadata:
-                    i+=1
-                    thekey = key+f' {i:02d}'
-                metadata[thekey] = val
-            #ignore rest
-            except ValueError:
-                pass
-        
-        self.metadata = metadata
-        
+        self.metadata = xml_root
         return self.metadata
         
+    def print_metadata(self):
+        """print formatted output of metadata"""
+        
+        try:
+            xml_root = self.metadata
+        except AttributeError:
+            xml_root = self.get_metadata()
+        
+        util.print_metadata(xml_root)
 
     def get_pixelsize(self):
         """
@@ -763,7 +854,117 @@ class ZeissSEM:
 
         """   
         metadata = self.get_metadata()
-        pixelsize,unit = metadata['Image Pixel Size'].split()
+        pixelsize,unit = metadata.find('AP_IMAGE_PIXEL_SIZE')\
+            .find('Image Pixel Size').text.split()
         
         return float(pixelsize), unit
         
+    def export_with_scalebar(self, filename=None, **kwargs):
+        """
+        saves an exported image of the SEM image with a scalebar in one of the 
+        four corners, where barsize is the scalebar size in data units (e.g. 
+        nm) and scale the overall size of the scalebar and text with respect to
+        the width of the image.
+
+        Parameters
+        ----------
+        filename : string or `None`, optional
+            Filename + extension to use for the export file. The default is the
+            filename sans extension of the original SEM file, with 
+            '_exported.png' appended.
+        crop : tuple or `None`, optional 
+            range describing a area of the original image (before rescaling the
+            resolution) to crop out for the export image. Can have two forms:
+                
+            - `((xmin,ymin),(xmax,ymax))`, with the integer indices of the top
+            left and bottom right corners respectively.
+                
+            - `(xmin,ymin,w,h)` with the integer indices of the top left corner
+            and the width and heigth of the cropped image in pixels (prior to 
+            optional rescaling using `resolution`).
+            
+            The default is `None` which takes the entire image.
+        resolution : int, optional
+            the resolution along the x-axis (i.e. image width in pixels) to use
+            for the exported image. The default is `None`, which uses the size 
+            of the original image (after optional cropping using `crop`).
+        draw_bar : boolean, optional
+            whether to draw a scalebar on the image, such that this function 
+            may be used just to crop and rescale. The default is `True`.
+        barsize : float or `None`, optional
+            size (in data units matching the original scale bar, e.g. nm) of 
+            the scale bar to use. The default `None`, wich takes the desired 
+            length for the current scale and round this to the nearest option
+            from a list of "nice" values.
+        scale : float, optional
+            factor to change the size of the scalebar+text with respect to the
+            width of the image. Scale is chosen such, that at `scale=1` the
+            font size of the scale bar text is approximately 10 pt when 
+            the image is printed at half the width of the text in a typical A4
+            paper document (e.g. two images side-by-side). The default is 1.
+        loc : int, one of [`0`,`1`,`2`,`3`], optional
+            Location of the scalebar on the image, where `0`, `1`, `2` and `3` 
+            refer to the top left, top right, bottom left and bottom right 
+            respectively. The default is `2`, which is the bottom left corner.
+        convert : one of ['pm', 'nm', 'um', 'µm', 'mm', 'm', None], optional
+            Unit that will be used for the scale bar, the value will be 
+            automatically converted if this unit differs from the pixel size
+            unit. The default is `None`, which uses the unit of the scalebar on
+            the original image.
+        font : str, optional
+            filename of an installed TrueType font ('.ttf' file) to use for the
+            text on the scalebar. The default is `'arialbd.ttf'`.
+        fontsize : int, optional
+            base font size to use for the scale bar text. The default is 16. 
+            Note that this size will be re-scaled according to `resolution` and
+            `scale`.
+        fontbaseline : int, optional
+            vertical offset for the baseline of the scale bar text in printer
+             points. The default is 0.
+        fontpad : int, optional
+            minimum size in printer points of the space/padding between the 
+            text and the bar and surrounding box. The default is 2.
+        barthickness : int, optional
+            thickness in printer points of the scale bar itself. The default is
+            16.
+        barpad : int, optional
+            size in printer points of the padding between the scale bar and the
+            surrounding box. The default is 10.
+        box : bool, optional
+            Whether to put a semitransparent box around the scalebar and text
+            to enhance contrast. The default is `True`.
+        boxalpha : float, optional
+            value between 0 and 1 for the opacity (inverse of transparency) of
+            the box behind the scalebar and text when `box=True`. The default 
+            is `0.6`.
+        invert : bool, optional
+            If `True`, a white scalebar and text on a black box are used. The 
+            default is `False` which gives black text on a white background.
+        boxpad : int, optional
+            size of the space/padding around the box (with respect to the sides
+            of the image) in printer points. The default is 10.
+        """
+        #check if pixelsize already calculated, otherwise call get_pixelsize
+        try:
+            pixelsize,unit = self.pixelsize,self.unit
+        except AttributeError:
+            pixelsize,unit = self.get_pixelsize()
+        
+        #set default export filename
+        if type(filename) != str:
+            filename = self.filename.rpartition('.')[0]+'_scalebar.png'
+        
+        #check we're not overwriting the original file
+        if filename==self.filename:
+            raise ValueError('overwriting original SEM file not recommended, '
+                             'use a different filename for exporting.')
+              
+        #get and display image
+        try:
+            exportim = self.image.copy()
+        except AttributeError:
+            exportim = self.get_image().copy()
+        
+        #call main export_with_scalebar function with correct pixelsize etc
+        from .utility import _export_with_scalebar
+        _export_with_scalebar(exportim, pixelsize, unit, filename, **kwargs)

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -668,3 +668,54 @@ class xl30sfeg:
         _export_with_scalebar(exportim, pixelsize, unit, filename, barsize, 
                               crop, scale, loc, resolution, box, invert, 
                               convert)
+
+
+
+class ZeissSEM:
+    """
+    
+    """
+    def __init__(self,filename):
+        """initialize class by storing the file name"""
+        
+        #raise error if wrong format or file does not exist
+        if type(filename) != str:
+            raise TypeError('filename must be a string')
+        if os.path.exists(filename):
+            self.filename = filename
+        elif os.path.exists(filename+'.tif'):
+                self.filename = filename + '.tif'
+        else:
+            raise FileNotFoundError('The file "'+filename+'" could not be '
+                                    'found.')
+
+    
+    def load_image(self):
+        """load the image and (if present) scalebar"""
+        self.image = cv2.imread(self.filename,0)
+        self.shape = np.shape(self.image)
+        return self.image
+    
+    def get_metadata(self):
+
+        from PIL.Image import open as PIL_open
+
+        tifftags = PIL_open(self.filename).tag
+        md1 = tifftags[34118][0].replace('\r','').split('\n')
+        md2 = tifftags[34119][0].replace('\x00','').replace('\r','').split('\n')
+        
+        metadata = dict()
+        for line in md1+md2:
+            #only accept if there's a '=' in the line
+            try:
+                key,val = line.split(' = ')
+                i = 0
+                while key in metadata:
+                    i+=1
+                    key+=f' {i:02d}'
+                metadata[key] = val
+            #ignore rest
+            except ValueError:
+                pass
+                
+        return metadata

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -21,13 +21,14 @@ class helios:
     def __init__(self,filename):
         #raise error if wrong format or file does not exist
         if type(filename) != str:
-            raise TypeError('The argument to the helios class must be a string containing the filename.')
+            raise TypeError('The argument to the helios class must be a string'
+                            ' containing the filename.')
         if not os.path.exists(filename):
             if os.path.exists(filename + '.tif'):
                 filename = filename + '.tif'
             else:
-                raise FileNotFoundError('The file "'+filename+'" could not be found.')
-            
+                raise FileNotFoundError('The file "'+filename+
+                                        '" could not be found.')
         self.filename = filename
     
     def load_image(self):

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -717,7 +717,7 @@ class ZeissSEM:
                 while thekey in metadata:
                     i+=1
                     thekey = key+f' {i:02d}'
-                metadata[key] = val
+                metadata[thekey] = val
             #ignore rest
             except ValueError:
                 pass

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -1,5 +1,4 @@
 import os
-#import cv2
 import numpy as np
 from .utility import util
 from PIL import Image

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -6,24 +6,19 @@ from .utility import util
 class helios:
     """
     Set of convenience functions for the Helios SEM.
+    
+    Parameters
+    ----------
+    filename : string
+        name of the file to load. Can but is not required to include .tif
+        as extension.
+
+
+    Returns
+    -------
+    helios class instance
     """
     def __init__(self,filename):
-        """
-        initialize class by loading the file
-
-        Parameters
-        ----------
-        filename : string
-            name of the file to load. Can but is not required to include .tif
-            as extension.
-
-
-        Returns
-        -------
-        None.
-
-        """
-        
         #raise error if wrong format or file does not exist
         if type(filename) != str:
             raise TypeError('The argument to the helios class must be a string containing the filename.')
@@ -278,10 +273,17 @@ class helios:
 class phenom:
     """
     Set of convenience functions for the phenom SEM microscopes.
+    
+    Parameters
+    ----------
+    filename : str
+        filename of the image to load
+        
+    Returns
+    -------
+    phenom class instance
     """
     def __init__(self,filename):
-        """Initialize the class instance"""
-        
         #raise error if wrong format or file does not exist
         if type(filename) != str:
             raise TypeError('The argument to the helios class must be a string containing the filename.')
@@ -477,10 +479,17 @@ class phenom:
 class xl30sfeg:
     """
     Set of convenience functions for the xl30sfeg SEM microscope.
+    
+    Parameters
+    ----------
+    filename : str
+        filename of the image to load
+        
+    Returns
+    -------
+    xl30sfeg class instance
     """
     def __init__(self,filename):
-        """initialize class by storing the file name"""
-        
         #raise error if wrong format or file does not exist
         if type(filename) != str:
             raise TypeError('The argument to the xl30sfeg class must be a string containing the filename.')
@@ -673,10 +682,18 @@ class xl30sfeg:
 
 class ZeissSEM:
     """
+    Class for the Zeiss EVO and Gemini SEMs'
     
+    Parameters
+    ----------
+    filename : str
+        filename of the image to load
+        
+    Returns
+    -------
+    ZeissSEM class instance
     """
     def __init__(self,filename):
-        """initialize class by storing the file name"""
         #raise error if wrong format or file does not exist
         if type(filename) != str:
             raise TypeError('filename must be a string')
@@ -690,13 +707,18 @@ class ZeissSEM:
 
     
     def load_image(self):
-        """load the image data"""
+        """loads the image data
+        
+        Returns
+        -------
+        PIL.Image instance
+        """
         self.image = cv2.imread(self.filename,0)
         self.shape = np.shape(self.image)
         return self.image
     
     def get_metadata(self):
-        
+        """extracts embedded metadata from the image file
         #don't reread if we already have it
         if hasattr(self,'metadata'):
             return self.metadata

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -718,7 +718,7 @@ class ZeissSEM:
         return self.image
     
     def get_metadata(self):
-        """extracts embedded metadata from the image file
+        """extracts embedded metadata from the image file"""
         #don't reread if we already have it
         if hasattr(self,'metadata'):
             return self.metadata
@@ -747,9 +747,11 @@ class ZeissSEM:
         self.metadata = metadata
         
         return self.metadata
+        
 
     def get_pixelsize(self):
-        """gets the physical size of a pixel from the metadata
+        """
+        gets the physical size of a pixel from the metadata
 
         Returns
         -------

--- a/scm_electron_microscopes/sem.py
+++ b/scm_electron_microscopes/sem.py
@@ -710,9 +710,10 @@ class ZeissSEM:
             try:
                 key,val = line.split(' = ')
                 i = 0
-                while key in metadata:
+                thekey = key.copy()
+                while thekey in metadata:
                     i+=1
-                    key+=f' {i:02d}'
+                    thekey = key+f' {i:02d}'
                 metadata[key] = val
             #ignore rest
             except ValueError:

--- a/scm_electron_microscopes/tem.py
+++ b/scm_electron_microscopes/tem.py
@@ -393,7 +393,7 @@ class tecnai:
         invert : bool, optional
             If `True`, a white scalebar and text on a black box are used. The 
             default is `False` which gives black text on a white background.
-        convert : str, one of [`pm`,`nm`,`um`,`µm`,`mm`,`m`], optional
+        convert : one of ['pm', 'nm', 'um', 'µm', 'mm', 'm', None], optional
             Unit that will be used for the scale bar, the value will be 
             automatically converted if this unit differs from the pixel size
             unit. The default is `None`, which uses the unit of the scalebar on

--- a/scm_electron_microscopes/tem.py
+++ b/scm_electron_microscopes/tem.py
@@ -170,14 +170,16 @@ class tecnai:
                 convert = 'µm'
             
             #check against list of allowed units
+            unit = 'm'
             units = ['pm','nm','µm','mm','m']
-            if not unit in units:
-                raise ValueError('"'+str(unit)+'" is not a valid unit')
+            if not convert in units:
+                raise ValueError('"'+str(convert)+'" is not a valid unit')
             
             #factor 10**3 for every step from list, use indices to calculate
             pixelsize_x = pixelsize_x*10**(
                 3*(units.index(unit)-units.index(convert))
             )
+            unit = convert
             
         #store and return
         self.pixelsize = pixelsize_x

--- a/scm_electron_microscopes/tem.py
+++ b/scm_electron_microscopes/tem.py
@@ -122,8 +122,10 @@ class tecnai:
         print('-----------------------------------------------------\n')
             
     
-    def get_pixelsize(self, debug=False):
+    def get_pixelsize_legacy(self, debug=False):
         """
+        *THIS FUNCTION IS DEPRECATED. USE `tecnai.get_pixelsize()`*
+        
         Reads the scalebar from images of the Tecnai TEM microscopes using 
         text recognition via pytesseract or with manual input when pytesseract
         is not installed
@@ -275,6 +277,56 @@ class tecnai:
         
         return pixelsize,unit
     
+    def get_pixelsize(self):
+        """
+        Gets the physical size represented by the pixels from the image 
+        metadata
+        
+        Returns
+        -------
+        pixelsize : float
+            the physical size of a pixel in the given unit
+        unit : str
+            physical unit of the pixel size
+        """
+        from PIL import Image
+        tags = Image.open(self.filename).tag
+        
+        #tiff tags 65450 and 65451 contain an int value for pixels per `x` cm,
+        #where x is a power of 10, e.g. 586350674 pixels per 100 cm is 
+        #encoded as (586350674, 100) and gives 1.7 nm/pixel
+        pixelsize_x = tags[65450][0]
+        pixelsize_x = 1e-2*pixelsize_x[1]/pixelsize_x[0]
+        
+        #pixelsize_y = tags[65451][0]
+        #pixelsize_y = 1e-2*pixelsize_y[1]/pixelsize_y[0]
+        
+        #find the right unit and rescale for convenience
+        if pixelsize_x >= 10e-3:
+            unit = 'm'
+        elif pixelsize_x < 10e-3 and pixelsize_x >= 10e-6:
+            unit = 'mm'
+            pixelsize_x = 1e3*pixelsize_x
+            #pixelsize_y = 1e3*pixelsize_y
+        elif pixelsize_x < 10e-6 and pixelsize_x >= 10e-9:
+            unit = 'µm'
+            pixelsize_x = 1e6*pixelsize_x
+            #pixelsize_y = 1e6*pixelsize_y
+        elif pixelsize_x < 10e-9 and pixelsize_x >= 10e-12:
+            unit = 'nm'
+            pixelsize_x = 1e9*pixelsize_x
+            #pixelsize_y = 1e9*pixelsize_y
+        else:
+            unit = 'pm'
+            pixelsize_x = 1e12*pixelsize_x
+            #pixelsize_y = 1e9*pixelsize_y
+        
+        #store and return
+        self.pixelsize = pixelsize_x
+        self.unit = unit
+        return (pixelsize_x,unit)
+        
+        
     def export_with_scalebar(self,filename=None,barsize=None,crop=None,scale=1,
                              loc=2,resolution=None,box=True,invert=False,
                              convert=None):

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "numpy>=1.19.2",
         "scipy>=1.6.0",
         "matplotlib>=3.0.0",
+        "opencv-python>=3.0.0",
         "pillow>=6.2.1",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="scm_electron_microscopes",
-    version="2.0.0",
+    version="2.0.1",
     author="Maarten Bransen",
     author_email="m.bransen@uu.nl",
     license='GNU General Public License v3.0',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="scm_electron_microscopes",
-    version="1.0.1",
+    version="2.0.0",
     author="Maarten Bransen",
     author_email="m.bransen@uu.nl",
     license='GNU General Public License v3.0',
@@ -12,7 +12,6 @@ setup(
         "numpy>=1.19.2",
         "scipy>=1.6.0",
         "matplotlib>=3.0.0",
-        "opencv-python>=3.0.0",
         "pillow>=6.2.1",
     ],
 )


### PR DESCRIPTION
Note that this version has some backwards incompatible changes:
- `load_image` functions have been renamed to `get_image`
- `load_metadata` functions have been renamed to `get_metadata`
- `tecnai.get_pixelsize` no longer uses text recognition to read the scale bar. This is faster and removes Pytesseract and the Tesseract OCR as dependencies, but yields slightly different (and more accurate) values. The old scaling method is available through `get_pixelsize_legacy`.
- all `get_metadata` functions now return an xml.etree.Elementtree object by default, rather than a dictionary which was used for some classes.